### PR TITLE
Dry up spec tests for subscriptions

### DIFF
--- a/spec/requests/api/v1/subscription/subscription_spec.rb
+++ b/spec/requests/api/v1/subscription/subscription_spec.rb
@@ -8,49 +8,43 @@ RSpec.describe "Subscriptions" do
             email: "bob@mcbobster.com", 
             address: "123 ABC St, Charlotte NC, 28226"
         )
+
+        @subscription = @customer.subscriptions.create({
+            title: "entry",
+            price: "15.99",
+            status: "1",
+            frequency: "1",
+        })
+
+        @body = {
+            title: "entry",
+            price: "15.99",
+            status: "1",
+            frequency: "1",
+            email: "bob@mcbobster.com"
+        }
     end
 
     describe 'endpoint creation' do
         it 'the POST - subscription endpoint exists' do
-            body = {
-                title: "entry",
-                price: "15.99",
-                status: "1",
-                frequency: "1",
-                email: "bob@mcbobster.com"
-            }
-            post '/api/v1/subscriptions', params: body
+            post '/api/v1/subscriptions', params: @body
             expect(response).to be_successful
             expect(response.status).to eq(200)
         end
 
         it "the PATCH - cancel a customer's subscription endpoint exists" do
-            subscription = @customer.subscriptions.create(
-                title: "entry",
-                price: "15.99",
-                status: "1",
-                frequency: "1"
-            )
-
             body = {
                 status: "0",
                 email: "bob@mcbobster.com"
             }
 
-            patch "/api/v1/subscriptions/#{subscription.id}", params: body
+            patch "/api/v1/subscriptions/#{@subscription.id}", params: body
 
             expect(response).to be_successful
             expect(response.status).to eq(200)
         end
 
         it "the GET - get all of a customer's subscription endpoint exists" do
-            subscription = @customer.subscriptions.create(
-                title: "entry",
-                price: "15.99",
-                status: "1",
-                frequency: "1"
-            )
-
             body = {
                 email: "bob@mcbobster.com"
             }
@@ -63,14 +57,7 @@ RSpec.describe "Subscriptions" do
 
     describe 'create a subscription' do
         it 'HAPPY PATH it can create a new subscription for a customer' do
-            body = {
-                title: "entry",
-                price: "15.99",
-                status: "1",
-                frequency: "1",
-                email: "bob@mcbobster.com"
-            }
-            post '/api/v1/subscriptions', params: body
+            post '/api/v1/subscriptions', params: @body
             subscription = JSON.parse(response.body, symbolize_names: true)
 
             expect(subscription[:message]).to eq("Subscription has been created")
@@ -97,18 +84,11 @@ RSpec.describe "Subscriptions" do
 
     describe 'cancel a subscription' do
         it 'HAPPY PATH can cancel a subscription for a customer' do
-            subscription = @customer.subscriptions.create(
-                title: "entry",
-                price: "15.99",
-                status: "1",
-                frequency: "1"
-            )
-
             body = {
                 status: "0",
             }
 
-            patch "/api/v1/subscriptions/#{subscription.id}", params: body
+            patch "/api/v1/subscriptions/#{@subscription.id}", params: body
             subscription = JSON.parse(response.body, symbolize_names: true)
 
             expect(subscription[:message]).to eq("Subscription has been updated")
@@ -117,18 +97,11 @@ RSpec.describe "Subscriptions" do
         end
 
         it 'SAD PATH can cancel a subscription for a customer' do
-            subscription = @customer.subscriptions.create(
-                title: "entry",
-                price: "15.99",
-                status: "1",
-                frequency: "1"
-            )
-
             body = {
                 status: "asdf"
             }
 
-            patch "/api/v1/subscriptions/#{subscription.id}", params: body
+            patch "/api/v1/subscriptions/#{@subscription.id}", params: body
             subscription = JSON.parse(response.body, symbolize_names: true)
 
             expect(subscription[:errors]).to eq("Incorrect status code given")
@@ -139,20 +112,6 @@ RSpec.describe "Subscriptions" do
 
     describe 'get all subscriptions by customer' do
         it 'HAPPY PATH can get all subscriptions by customer' do
-            subscription_1 = @customer.subscriptions.create(
-                title: "entry",
-                price: "15.99",
-                status: "1",
-                frequency: "1"
-            )
-
-            subscription_2 = @customer.subscriptions.create(
-                title: "advanced",
-                price: "45",
-                status: "0",
-                frequency: "4"
-            )
-
             body = {
                 email: "bob@mcbobster.com"
             }
@@ -163,7 +122,7 @@ RSpec.describe "Subscriptions" do
             expect(response.status).to eq(200)
             expect(response).to be_successful
             
-            expect(subscription[:data].count).to eq(2)
+            expect(subscription[:data].count).to eq(1)
             expect(subscription[:data].first[:attributes]).to have_key(:title)
             expect(subscription[:data].first[:attributes]).to have_key(:price)
             expect(subscription[:data].first[:attributes]).to have_key(:status)
@@ -171,20 +130,6 @@ RSpec.describe "Subscriptions" do
         end
 
         it 'SAD PATH can get all subscriptions by customer' do
-            subscription_1 = @customer.subscriptions.create(
-                title: "entry",
-                price: "15.99",
-                status: "1",
-                frequency: "1"
-            )
-
-            subscription_2 = @customer.subscriptions.create(
-                title: "advanced",
-                price: "45",
-                status: "0",
-                frequency: "4"
-            )
-
             body = {
                 email: "asdf@asdf.com"
             }


### PR DESCRIPTION
Spec tests altered to DRY up code by putting body/param blocks into a before :each block. 